### PR TITLE
clickable/draggable file icon rather than "File:"

### DIFF
--- a/Avenue.xcodeproj/project.pbxproj
+++ b/Avenue.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		1235A0242587C7C800365811 /* GPXTileServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FF818324AF7D02001A2DB3 /* GPXTileServer.swift */; };
 		1235A03D2587D69300365811 /* ElapsedTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D43C6824D090A90075B8B8 /* ElapsedTime.swift */; };
 		1235A0412587D69800365811 /* Double+Measures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122BD57A249F4C63006FBB2F /* Double+Measures.swift */; };
+		1265BC6D289FCF3E0058BFDF /* DraggableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1265BC6C289FCF3E0058BFDF /* DraggableImageView.swift */; };
+		1265BC6F289FCFD20058BFDF /* NSImagesExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1265BC6E289FCFD20058BFDF /* NSImagesExtensions.swift */; };
 		1266EC98289E5C5800A098B8 /* PageSetupCellButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1266EC97289E5C5800A098B8 /* PageSetupCellButton.swift */; };
 		1266EC9A289E7F3100A098B8 /* PageSetupResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1266EC99289E7F3100A098B8 /* PageSetupResolution.swift */; };
 		1292DD3E289D1F7B00D42E77 /* MKSnapshotDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1292DD3D289D1F7B00D42E77 /* MKSnapshotDrawer.swift */; };
@@ -97,6 +99,8 @@
 		12359FE62587C27300365811 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/PreviewViewController.xib; sourceTree = "<group>"; };
 		12359FE82587C27300365811 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		12359FE92587C27300365811 /* GPXQuickLook.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GPXQuickLook.entitlements; sourceTree = "<group>"; };
+		1265BC6C289FCF3E0058BFDF /* DraggableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggableImageView.swift; sourceTree = "<group>"; };
+		1265BC6E289FCFD20058BFDF /* NSImagesExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSImagesExtensions.swift; sourceTree = "<group>"; };
 		1266EC97289E5C5800A098B8 /* PageSetupCellButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageSetupCellButton.swift; sourceTree = "<group>"; };
 		1266EC99289E7F3100A098B8 /* PageSetupResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageSetupResolution.swift; sourceTree = "<group>"; };
 		1292DD3D289D1F7B00D42E77 /* MKSnapshotDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MKSnapshotDrawer.swift; sourceTree = "<group>"; };
@@ -239,6 +243,8 @@
 				122BD57A249F4C63006FBB2F /* Double+Measures.swift */,
 				12D81ABC289C2FD500E5BE2E /* CGSize+Multiplier.swift */,
 				1292DD3D289D1F7B00D42E77 /* MKSnapshotDrawer.swift */,
+				1265BC6C289FCF3E0058BFDF /* DraggableImageView.swift */,
+				1265BC6E289FCFD20058BFDF /* NSImagesExtensions.swift */,
 			);
 			path = Avenue;
 			sourceTree = "<group>";
@@ -417,6 +423,7 @@
 				12D81ABD289C2FD500E5BE2E /* CGSize+Multiplier.swift in Sources */,
 				1292DD3E289D1F7B00D42E77 /* MKSnapshotDrawer.swift in Sources */,
 				BF4F5AB122D1FBCD00C8E95A /* ViewController.swift in Sources */,
+				1265BC6F289FCFD20058BFDF /* NSImagesExtensions.swift in Sources */,
 				12D43C6924D090A90075B8B8 /* ElapsedTime.swift in Sources */,
 				1292DD41289D6DFF00D42E77 /* AdditionalPageSetupViewController.swift in Sources */,
 				BFF76B5422D36F4500C269D8 /* WindowController.swift in Sources */,
@@ -428,6 +435,7 @@
 				122BD57B249F4C63006FBB2F /* Double+Measures.swift in Sources */,
 				BFF76B5622D3819100C269D8 /* MapView.swift in Sources */,
 				BF4F5AAF22D1FBCD00C8E95A /* AppDelegate.swift in Sources */,
+				1265BC6D289FCF3E0058BFDF /* DraggableImageView.swift in Sources */,
 				12FF818424AF7D02001A2DB3 /* GPXTileServer.swift in Sources */,
 				BF4F5AB322D1FBCD00C8E95A /* Document.swift in Sources */,
 				BF9CFB0922F0787700658566 /* GPXWaypoint+MKAnnotation.swift in Sources */,

--- a/Avenue/Base.lproj/Main.storyboard
+++ b/Avenue/Base.lproj/Main.storyboard
@@ -451,7 +451,7 @@
                                 <toolbarItem implicitItemIdentifier="860EE761-8452-4733-A7FB-A5C2BABAB57A" label="Distance" paletteLabel="Distance" sizingBehavior="auto" id="x6A-dH-1Dg">
                                     <nil key="toolTip"/>
                                     <textField key="view" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Uub-Ud-ev7">
-                                        <rect key="frame" x="0.0" y="14" width="87" height="22"/>
+                                        <rect key="frame" x="0.0" y="14" width="88" height="22"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" allowsUndo="NO" borderStyle="bezel" alignment="center" placeholderString="Loading..." usesSingleLineMode="YES" bezelStyle="round" id="Xxw-0s-Bts">
                                             <font key="font" metaFont="systemMedium" size="13"/>
@@ -460,8 +460,17 @@
                                         </textFieldCell>
                                     </textField>
                                 </toolbarItem>
+                                <toolbarItem implicitItemIdentifier="87DE77C2-DFDA-482C-88E4-6359E1F9FE87" label="File Icon" paletteLabel="File Icon" image="NSMultipleDocuments" sizingBehavior="auto" id="TPj-xy-Mux">
+                                    <nil key="toolTip"/>
+                                    <imageView key="view" horizontalHuggingPriority="251" verticalHuggingPriority="251" id="krd-y8-kwy" customClass="DraggableImageView" customModule="Avenue" customModuleProvider="target">
+                                        <rect key="frame" x="15" y="14" width="22" height="22"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" image="NSMultipleDocuments" id="IgI-gl-GD6"/>
+                                    </imageView>
+                                </toolbarItem>
                             </allowedToolbarItems>
                             <defaultToolbarItems>
+                                <toolbarItem reference="TPj-xy-Mux"/>
                                 <toolbarItem reference="9NC-dN-VgB"/>
                                 <toolbarItem reference="S0k-PL-XeI"/>
                                 <toolbarItem reference="x6A-dH-1Dg"/>
@@ -474,6 +483,7 @@
                     <connections>
                         <outlet property="barDistance" destination="Uub-Ud-ev7" id="iDN-BJ-kgS"/>
                         <outlet property="barTitle" destination="lI5-bJ-PDa" id="R2k-6b-giL"/>
+                        <outlet property="fileImageView" destination="krd-y8-kwy" id="Qfa-eg-Tp8"/>
                         <segue destination="5gI-5U-AMq" kind="relationship" relationship="window.shadowedContentViewController" id="nsd-lR-9xd"/>
                     </connections>
                 </windowController>
@@ -750,5 +760,6 @@
     </scenes>
     <resources>
         <image name="NSApplicationIcon" width="32" height="32"/>
+        <image name="NSMultipleDocuments" width="32" height="32"/>
     </resources>
 </document>

--- a/Avenue/Document.swift
+++ b/Avenue/Document.swift
@@ -34,10 +34,10 @@ class Document: NSDocument {
         let windowController = storyboard.instantiateController(withIdentifier: NSStoryboard.SceneIdentifier("Document Window Controller")) as! WindowController
         
         if let fileName = self.fileURL?.lastPathComponent {
-            let systemRegular = [ NSAttributedString.Key.font: NSFont.systemFont(ofSize: 18, weight: .regular) ]
+            //let systemRegular = [ NSAttributedString.Key.font: NSFont.systemFont(ofSize: 18, weight: .regular) ]
             let systemSemibold = [ NSAttributedString.Key.font: NSFont.systemFont(ofSize: 18, weight: .semibold) ]
-            let title = NSMutableAttributedString(string: "File: \(fileName)", attributes: systemSemibold)
-            title.addAttributes(systemRegular, range: NSMakeRange(0, 5))
+            let title = NSMutableAttributedString(string: "\(fileName)", attributes: systemSemibold)
+            //title.addAttributes(systemRegular, range: NSMakeRange(0, 5))
             
             //windowController.barTitle.stringValue = "Avenue - \(title)"
             windowController.barTitle.attributedStringValue = title
@@ -49,6 +49,11 @@ class Document: NSDocument {
         //viewController.mapView.loadedGPXFile(gpx)
         viewController.mapView.loadedGPXData(data, windowController)
         viewController.filePath = fileURL?.absoluteString ?? ""
+        Swift.print(viewController.filePath)
+            
+        windowController.fileImageView.image = NSWorkspace.shared.icon(forFileType: "public.gpx").resize(withSize: NSSize(width: 22, height: 22))
+        windowController.fileImageView.fileURL = fileURL
+        
         appDelegate.enableViewMenuItem()
         //viewController.mmHidden = !UserDefaults.standard.bool(forKey: "showMiniMap")
     }

--- a/Avenue/DraggableImageView.swift
+++ b/Avenue/DraggableImageView.swift
@@ -1,0 +1,119 @@
+//
+//  DraggableImageView.swift
+//
+//  https://github.com/raphaelhanneken/iconizer
+//  https://gist.github.com/raphaelhanneken/d77b6f9b01bef35709da
+//
+
+import Cocoa
+
+class DraggableImageView: NSImageView, NSDraggingSource {
+
+    /// Holds the last mouse down event, to track the drag distance.
+    var mouseDownEvent: NSEvent?
+    var fileURL: URL?
+    var darkenFilter: CIFilter?
+    
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+    }
+
+    // MARK: - NSDraggingSource
+    
+    func draggingSession(_: NSDraggingSession,
+                         sourceOperationMaskFor _: NSDraggingContext) -> NSDragOperation {
+        return .copy
+    }
+    
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if let source = sender.draggingSource as? Self, source == self {
+            return NSDragOperation.link
+        }
+        else {
+            return NSDragOperation()
+        }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if darkenFilter == nil {
+            guard let filter = CIFilter(name: "CIExposureAdjust") else { return }
+            filter.setValue(-1.0, forKey: "inputEV")
+            self.darkenFilter = filter
+        }
+        
+        self.compositingFilter = darkenFilter
+        self.mouseDownEvent = event
+        
+        if let fileURL = fileURL, event.clickCount == 2 {
+            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+        }
+    }
+    
+    override func mouseUp(with event: NSEvent) {
+        self.compositingFilter = nil
+    }
+
+    // Track mouse dragged events to handle dragging sessions.
+    override func mouseDragged(with event: NSEvent) {
+
+        // Calculate the dragging distance...
+        let mouseDown = mouseDownEvent!.locationInWindow
+        let dragPoint = event.locationInWindow
+        let dragDistance = hypot(mouseDown.x - dragPoint.x, mouseDown.y - dragPoint.y)
+
+        // Cancel the dragging session in case of an accidental drag.
+        if dragDistance < 3 {
+            return
+        }
+
+        guard let image = self.image else {
+            return
+        }
+
+        // Do some math to properly resize the given image.
+        let size = NSSize(width: log10(image.size.width) * 30, height: log10(image.size.height) * 30)
+
+        if let draggingImage = image.crop(toSize: size) {
+
+            guard let fileURL = fileURL else {
+                return
+            }
+            
+            // Create a new NSDraggingItem with the image as content.
+            let draggingItem = NSDraggingItem(pasteboardWriter: fileURL as NSURL)
+
+            // Calculate the mouseDown location from the window's coordinate system to the
+            // ImageView's coordinate system, to use it as origin for the dragging frame.
+            let draggingFrameOrigin = convert(mouseDown, from: nil)
+            // Build the dragging frame and offset it by half the image size on each axis
+            // to center the mouse cursor within the dragging frame.
+            let draggingFrame = NSRect(origin: draggingFrameOrigin, size: draggingImage.size)
+                .offsetBy(dx: -draggingImage.size.width / 2, dy: -draggingImage.size.height / 2)
+
+            // Assign the dragging frame to the draggingFrame property of our dragging item.
+            draggingItem.draggingFrame = draggingFrame
+
+            // Provide the components of the dragging image.
+            draggingItem.imageComponentsProvider = {
+                let component = NSDraggingImageComponent(key: NSDraggingItem.ImageComponentKey.icon)
+
+                component.contents = image
+                component.frame = NSRect(origin: NSPoint(), size: draggingFrame.size)
+                return [component]
+            }
+            
+
+            // Begin actual dragging session. Woohow!
+            beginDraggingSession(with: [draggingItem], event: mouseDownEvent!, source: self)
+        }
+    }
+}

--- a/Avenue/NSImagesExtensions.swift
+++ b/Avenue/NSImagesExtensions.swift
@@ -1,0 +1,112 @@
+//
+// NSImageExtensions.swift
+// https://gist.github.com/raphaelhanneken/cb924aa280f4b9dbb480
+//
+import Cocoa
+
+extension NSImage {
+
+    /// The height of the image.
+    var height: CGFloat {
+        return size.height
+    }
+
+    /// The width of the image.
+    var width: CGFloat {
+        return size.width
+    }
+
+    /// A PNG representation of the image.
+    var PNGRepresentation: Data? {
+        if let tiff = self.tiffRepresentation, let tiffData = NSBitmapImageRep(data: tiff) {
+            return tiffData.representation(using: .png, properties: [:])
+        }
+
+        return nil
+    }
+
+    // MARK: Resizing
+    /// Resize the image to the given size.
+    ///
+    /// - Parameter size: The size to resize the image to.
+    /// - Returns: The resized image.
+    func resize(withSize targetSize: NSSize) -> NSImage? {
+        let frame = NSRect(x: 0, y: 0, width: targetSize.width, height: targetSize.height)
+        guard let representation = self.bestRepresentation(for: frame, context: nil, hints: nil) else {
+            return nil
+        }
+        let image = NSImage(size: targetSize, flipped: false, drawingHandler: { (_) -> Bool in
+            return representation.draw(in: frame)
+        })
+
+        return image
+    }
+
+    /// Copy the image and resize it to the supplied size, while maintaining it's
+    /// original aspect ratio.
+    ///
+    /// - Parameter size: The target size of the image.
+    /// - Returns: The resized image.
+    func resizeMaintainingAspectRatio(withSize targetSize: NSSize) -> NSImage? {
+        let newSize: NSSize
+        let widthRatio  = targetSize.width / self.width
+        let heightRatio = targetSize.height / self.height
+
+        if widthRatio > heightRatio {
+            newSize = NSSize(width: floor(self.width * widthRatio),
+                             height: floor(self.height * widthRatio))
+        } else {
+            newSize = NSSize(width: floor(self.width * heightRatio),
+                             height: floor(self.height * heightRatio))
+        }
+        return self.resize(withSize: newSize)
+    }
+
+    // MARK: Cropping
+    /// Resize the image, to nearly fit the supplied cropping size
+    /// and return a cropped copy the image.
+    ///
+    /// - Parameter size: The size of the new image.
+    /// - Returns: The cropped image.
+    func crop(toSize targetSize: NSSize) -> NSImage? {
+        guard let resizedImage = self.resizeMaintainingAspectRatio(withSize: targetSize) else {
+            return nil
+        }
+        let x     = floor((resizedImage.width - targetSize.width) / 2)
+        let y     = floor((resizedImage.height - targetSize.height) / 2)
+        let frame = NSRect(x: x, y: y, width: targetSize.width, height: targetSize.height)
+
+        guard let representation = resizedImage.bestRepresentation(for: frame, context: nil, hints: nil) else {
+            return nil
+        }
+
+        let image = NSImage(size: targetSize,
+                            flipped: false,
+                            drawingHandler: { (destinationRect: NSRect) -> Bool in
+            return representation.draw(in: destinationRect)
+        })
+
+        return image
+    }
+
+    // MARK: Saving
+    /// Save the images PNG representation the the supplied file URL:
+    ///
+    /// - Parameter url: The file URL to save the png file to.
+    /// - Throws: An unwrappingPNGRepresentationFailed when the image has no png representation.
+    func savePngTo(url: URL) throws {
+        if let png = self.PNGRepresentation {
+            try png.write(to: url, options: .atomicWrite)
+        } else {
+            throw NSImageExtensionError.unwrappingPNGRepresentationFailed
+        }
+    }
+}
+
+
+/// Exceptions for the image extension class.
+///
+/// - creatingPngRepresentationFailed: Is thrown when the creation of the png representation failed.
+enum NSImageExtensionError: Error {
+    case unwrappingPNGRepresentationFailed
+}

--- a/Avenue/WindowController.swift
+++ b/Avenue/WindowController.swift
@@ -12,6 +12,7 @@ class WindowController: NSWindowController {
     
     @IBOutlet weak var barTitle: NSTextField!
     @IBOutlet weak var barDistance: NSTextField!
+    @IBOutlet weak var fileImageView: DraggableImageView!
     
     private var dropDownIndex = [String : Int]() // filePath : idx
     
@@ -21,7 +22,6 @@ class WindowController: NSWindowController {
         // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
         barTitle.stringValue = "Avenue"
         barTitle.isHidden = true
-        
         if #available(OSX 10.12, *) {
             window?.tabbingMode = .preferred
         }


### PR DESCRIPTION
<img width="200" alt="Screenshot 2022-08-07 at 7 27 45 PM" src="https://user-images.githubusercontent.com/23420208/183288329-74a77e66-d43e-457b-82aa-d0e86092702d.png">

New file icon that can be:
1. Double clicked to reveal file in Finder.
2. Drag and drop to quickly share the currently opened GPX file.